### PR TITLE
Uncomment explicit template instantiation for SPARSE_MATRIX_FLAT_NXN

### DIFF
--- a/PhysBAM_Tools/Matrices/SPARSE_MATRIX_FLAT_NXN.cpp
+++ b/PhysBAM_Tools/Matrices/SPARSE_MATRIX_FLAT_NXN.cpp
@@ -424,9 +424,9 @@ Conjugate_With_Diagonal_Matrix(VECTOR_ND<T>& x)
 //    output_stream<<std::endl;}
 //return output_stream;}
 ////#####################################################################
-//template class SPARSE_MATRIX_FLAT_NXN<float>;
+template class SPARSE_MATRIX_FLAT_NXN<float>;
 //template std::ostream& operator<<(std::ostream&,const SPARSE_MATRIX_FLAT_NXN<float>&);
-//#ifndef COMPILE_WITHOUT_DOUBLE_SUPPORT
-//template class SPARSE_MATRIX_FLAT_NXN<double>;
+#ifndef COMPILE_WITHOUT_DOUBLE_SUPPORT
+template class SPARSE_MATRIX_FLAT_NXN<double>;
 //template std::ostream& operator<<(std::ostream&,const SPARSE_MATRIX_FLAT_NXN<double>&);
-//#endif
+#endif


### PR DESCRIPTION
Hey guys,

For some reason the explicit template instantiation was commented out for SPARSE_MATRIX_FLAT_NXN which was causing linker errors for the smoke project.  This PR fixes it.